### PR TITLE
fix: add download_s3_prefix, deprecate download_s3_objects

### DIFF
--- a/helia_edge/utils/__init__.py
+++ b/helia_edge/utils/__init__.py
@@ -16,7 +16,7 @@ The `utils` module provides utility functions to help with common tasks such as 
 
 """
 
-from .aws import download_s3_file, download_s3_object, download_s3_objects
+from .aws import download_s3_file, download_s3_object, download_s3_objects, download_s3_prefix
 from .env import env_flag, setup_logger, silence_tensorflow
 from .export import helia_export
 from .factory import ItemFactory, create_factory

--- a/helia_edge/utils/aws.py
+++ b/helia_edge/utils/aws.py
@@ -303,9 +303,9 @@ def download_s3_prefix(
     norm_prefix = prefix.rstrip("/") + "/" if prefix and not prefix.endswith("/") else prefix
 
     client = _get_s3_client(config)
-    items = _list_s3_objects(client, bucket, prefix)
+    items = _list_s3_objects(client, bucket, norm_prefix)
 
-    logger.debug(f"Found {len(items)} objects in s3://{bucket}/{prefix}")
+    logger.debug(f"Found {len(items)} objects in s3://{bucket}/{norm_prefix}")
 
     os.makedirs(dst, exist_ok=True)
 

--- a/helia_edge/utils/aws.py
+++ b/helia_edge/utils/aws.py
@@ -5,14 +5,16 @@ This module provides utility functions to interact with AWS services.
 Functions:
     download_s3_file: Download a file from S3
     download_s3_object: Download an object from S3
-    download_s3_objects: Download all objects in a S3 bucket with a given prefix
+    download_s3_prefix: Download all objects under an S3 prefix into a local directory
+    download_s3_objects: Download all objects in a S3 bucket with a given prefix (deprecated)
 
 
 """
 
 import os
+import warnings
 import functools
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import boto3
@@ -131,6 +133,8 @@ def download_s3_object(
     if client is None:
         client = _get_s3_client()
 
+    os.makedirs(dst.parent, exist_ok=True)
+
     client.download_file(
         Bucket=bucket,
         Key=item["Key"],
@@ -149,7 +153,14 @@ def download_s3_objects(
     num_workers: int | None = None,
     config: Config | None = Config(signature_version=UNSIGNED),
 ):
-    """Download all objects in a S3 bucket with a given prefix
+    """Download all objects in a S3 bucket with a given prefix.
+
+    .. deprecated::
+        Use :func:`download_s3_prefix` instead.  This function preserves the
+        full S3 key (including the prefix) when building local paths, which
+        causes files to be nested one level too deep when ``dst`` already
+        contains the prefix directory.  The replacement strips the prefix so
+        that ``dst`` is always the root of the downloaded tree.
 
     Args:
         bucket (str): Bucket name
@@ -161,6 +172,13 @@ def download_s3_objects(
         config (Config | None, optional): Boto3 config. Defaults to Config(signature_version=UNSIGNED).
 
     """
+
+    warnings.warn(
+        "download_s3_objects is deprecated and has a known path-nesting bug. "
+        "Use download_s3_prefix instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     client = _get_s3_client(config)
 
@@ -203,3 +221,123 @@ def download_s3_objects(
                 pbar.update(1)
         # END FOR
     # END WITH
+
+
+def _list_s3_objects(
+    client: boto3.client,
+    bucket: str,
+    prefix: str,
+) -> list[dict]:
+    """Paginate through all objects under *prefix* in *bucket*.
+
+    Args:
+        client (boto3.client): S3 client.
+        bucket (str): Bucket name.
+        prefix (str): Key prefix.
+
+    Returns:
+        list[dict]: Object metadata dicts from ``list_objects_v2``.
+    """
+    items: list[dict] = []
+    next_token = None
+    while True:
+        kwargs: dict = {"Bucket": bucket, "Prefix": prefix}
+        if next_token is not None:
+            kwargs["ContinuationToken"] = next_token
+        response = client.list_objects_v2(**kwargs)
+        items.extend(response.get("Contents", []))
+        next_token = response.get("NextContinuationToken")
+        if next_token is None:
+            break
+    return items
+
+
+def download_s3_prefix(
+    bucket: str,
+    prefix: str,
+    dst: Path,
+    checksum: str = "size",
+    progress: bool = True,
+    num_workers: int | None = None,
+    config: Config | None = Config(signature_version=UNSIGNED),
+) -> int:
+    """Download all objects under an S3 prefix into a local directory.
+
+    Unlike :func:`download_s3_objects`, this function **strips the prefix**
+    from each object key before joining it with *dst*, so that *dst* becomes
+    the root of the downloaded tree.
+
+    Example::
+
+        # S3 objects:  s3://my-bucket/datasets/ptbxl/00001.h5
+        #              s3://my-bucket/datasets/ptbxl/00002.h5
+        download_s3_prefix(
+            bucket="my-bucket",
+            prefix="datasets/ptbxl",
+            dst=Path("./data/ptbxl"),
+        )
+        # Results in: ./data/ptbxl/00001.h5
+        #             ./data/ptbxl/00002.h5
+
+    Args:
+        bucket (str): Bucket name.
+        prefix (str): Key prefix to filter objects.  A trailing ``/`` is
+            added automatically if missing.
+        dst (Path): Local directory that will mirror the contents found
+            under *prefix*.
+        checksum (str, optional): Checksum strategy (``"size"`` or
+            ``"md5"``). Defaults to ``"size"``.
+        progress (bool, optional): Show a ``tqdm`` progress bar.
+            Defaults to ``True``.
+        num_workers (int | None, optional): Thread-pool size.  ``None``
+            uses the :class:`~concurrent.futures.ThreadPoolExecutor`
+            default.
+        config (Config | None, optional): Boto3 client config.
+            Defaults to unsigned requests.
+
+    Returns:
+        int: Number of objects downloaded (excludes skipped / up-to-date).
+    """
+
+    # Normalise prefix so stripping is reliable.
+    norm_prefix = prefix.rstrip("/") + "/" if prefix and not prefix.endswith("/") else prefix
+
+    client = _get_s3_client(config)
+    items = _list_s3_objects(client, bucket, prefix)
+
+    logger.debug(f"Found {len(items)} objects in s3://{bucket}/{prefix}")
+
+    os.makedirs(dst, exist_ok=True)
+
+    func = functools.partial(download_s3_object, bucket=bucket, client=client, checksum=checksum)
+    downloaded = 0
+
+    pbar = tqdm(total=len(items), unit="files") if progress else None
+
+    def _local_path(key: str) -> Path:
+        """Strip the prefix and join onto *dst*."""
+        relative = key[len(norm_prefix):] if key.startswith(norm_prefix) else key
+        return dst / PurePosixPath(relative)
+
+    with ThreadPoolExecutor(max_workers=num_workers) as executor:
+        futures = {
+            executor.submit(func, item, _local_path(item["Key"])): item
+            for item in items
+        }
+        for future in as_completed(futures):
+            err = future.exception()
+            if err:
+                item = futures[future]
+                logger.exception("Failed downloading %s", item["Key"])
+            else:
+                if future.result():
+                    downloaded += 1
+            if pbar:
+                pbar.update(1)
+        # END FOR
+    # END WITH
+
+    if pbar:
+        pbar.close()
+
+    return downloaded

--- a/tests/utils/test_aws.py
+++ b/tests/utils/test_aws.py
@@ -1,0 +1,214 @@
+"""Tests for S3 download utilities in helia_edge.utils.aws."""
+
+import os
+import warnings
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from helia_edge.utils.aws import (
+    download_s3_objects,
+    download_s3_prefix,
+    _list_s3_objects,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_s3_listing(prefix: str, files: list[str]) -> list[dict]:
+    """Build a list of S3 object metadata dicts."""
+    items = []
+    for f in files:
+        key = f"{prefix.rstrip('/')}/{f}"
+        if key.endswith("/"):
+            items.append({"Key": key, "Size": 0, "ETag": '""'})
+        else:
+            items.append({"Key": key, "Size": 100, "ETag": '"abc"'})
+    return items
+
+
+def _mock_client_for(items: list[dict]) -> MagicMock:
+    """Create a mock S3 client that returns *items* from list_objects_v2."""
+    client = MagicMock()
+    client.list_objects_v2.return_value = {
+        "Contents": items,
+    }
+    # download_file just touches the destination
+    def fake_download(Bucket, Key, Filename):
+        Path(Filename).parent.mkdir(parents=True, exist_ok=True)
+        Path(Filename).write_text(Key)
+
+    client.download_file.side_effect = fake_download
+    return client
+
+
+# ---------------------------------------------------------------------------
+# download_s3_objects (deprecated) — verify behaviour preserved
+# ---------------------------------------------------------------------------
+
+def test_download_s3_objects_emits_deprecation_warning(tmp_path):
+    """Old function must emit a DeprecationWarning."""
+    items = _fake_s3_listing("myprefix", ["a.txt"])
+    client = _mock_client_for(items)
+
+    with warnings.catch_warnings(record=True) as w, \
+         patch("helia_edge.utils.aws._get_s3_client", return_value=client):
+        warnings.simplefilter("always")
+        download_s3_objects(
+            bucket="b",
+            prefix="myprefix",
+            dst=tmp_path,
+            progress=False,
+        )
+    dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+    assert len(dep_warnings) == 1
+    assert "download_s3_prefix" in str(dep_warnings[0].message)
+
+
+def test_download_s3_objects_preserves_full_key(tmp_path):
+    """Legacy function should still nest the full key (bug preserved)."""
+    items = _fake_s3_listing("data", ["f1.h5", "f2.h5"])
+    client = _mock_client_for(items)
+
+    with warnings.catch_warnings(record=True), \
+         patch("helia_edge.utils.aws._get_s3_client", return_value=client):
+        warnings.simplefilter("always")
+        download_s3_objects(
+            bucket="b",
+            prefix="data",
+            dst=tmp_path,
+            progress=False,
+        )
+    # With the old bug, files land at dst / "data" / file
+    assert (tmp_path / "data" / "f1.h5").exists()
+    assert (tmp_path / "data" / "f2.h5").exists()
+
+
+# ---------------------------------------------------------------------------
+# download_s3_prefix — new correct function
+# ---------------------------------------------------------------------------
+
+def test_download_s3_prefix_strips_prefix(tmp_path):
+    """Files should land directly under dst, not nested under the prefix."""
+    items = _fake_s3_listing("datasets/ptbxl", ["00001.h5", "00002.h5"])
+    client = _mock_client_for(items)
+
+    with patch("helia_edge.utils.aws._get_s3_client", return_value=client):
+        n = download_s3_prefix(
+            bucket="b",
+            prefix="datasets/ptbxl",
+            dst=tmp_path / "ptbxl",
+            progress=False,
+        )
+    assert (tmp_path / "ptbxl" / "00001.h5").exists()
+    assert (tmp_path / "ptbxl" / "00002.h5").exists()
+    # Must NOT have the prefix duplicated
+    assert not (tmp_path / "ptbxl" / "datasets").exists()
+    assert n == 2
+
+
+def test_download_s3_prefix_with_trailing_slash(tmp_path):
+    """Prefix with trailing slash should work identically."""
+    items = _fake_s3_listing("mydata", ["sub/a.bin"])
+    client = _mock_client_for(items)
+
+    with patch("helia_edge.utils.aws._get_s3_client", return_value=client):
+        download_s3_prefix(
+            bucket="b",
+            prefix="mydata/",
+            dst=tmp_path,
+            progress=False,
+        )
+    assert (tmp_path / "sub" / "a.bin").exists()
+
+
+def test_download_s3_prefix_nested_structure(tmp_path):
+    """Nested sub-directories under the prefix should be preserved."""
+    items = _fake_s3_listing("root", ["a/b/c.txt", "a/d.txt", "e.txt"])
+    client = _mock_client_for(items)
+
+    with patch("helia_edge.utils.aws._get_s3_client", return_value=client):
+        download_s3_prefix(
+            bucket="b",
+            prefix="root",
+            dst=tmp_path,
+            progress=False,
+        )
+    assert (tmp_path / "a" / "b" / "c.txt").exists()
+    assert (tmp_path / "a" / "d.txt").exists()
+    assert (tmp_path / "e.txt").exists()
+
+
+def test_download_s3_prefix_skips_directory_markers(tmp_path):
+    """Keys ending with '/' are directory markers and should not create files."""
+    items = [
+        {"Key": "pfx/subdir/", "Size": 0, "ETag": '""'},
+        {"Key": "pfx/subdir/file.txt", "Size": 42, "ETag": '"x"'},
+    ]
+    client = _mock_client_for(items)
+
+    with patch("helia_edge.utils.aws._get_s3_client", return_value=client):
+        download_s3_prefix(
+            bucket="b",
+            prefix="pfx",
+            dst=tmp_path,
+            progress=False,
+        )
+    assert (tmp_path / "subdir").is_dir()
+    assert (tmp_path / "subdir" / "file.txt").exists()
+
+
+def test_download_s3_prefix_returns_count(tmp_path):
+    """Return value should reflect how many files were actually downloaded."""
+    items = _fake_s3_listing("p", ["a.txt", "b.txt", "c.txt"])
+    client = _mock_client_for(items)
+
+    with patch("helia_edge.utils.aws._get_s3_client", return_value=client):
+        n = download_s3_prefix(
+            bucket="b",
+            prefix="p",
+            dst=tmp_path,
+            progress=False,
+        )
+    assert n == 3
+
+
+def test_download_s3_prefix_empty_listing(tmp_path):
+    """An empty listing should succeed and return 0."""
+    client = MagicMock()
+    client.list_objects_v2.return_value = {"Contents": []}
+
+    with patch("helia_edge.utils.aws._get_s3_client", return_value=client):
+        n = download_s3_prefix(
+            bucket="b",
+            prefix="nothing",
+            dst=tmp_path,
+            progress=False,
+        )
+    assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# _list_s3_objects pagination
+# ---------------------------------------------------------------------------
+
+def test_list_s3_objects_paginates():
+    """Should follow NextContinuationToken until exhausted."""
+    client = MagicMock()
+    client.list_objects_v2.side_effect = [
+        {
+            "Contents": [{"Key": "p/a.txt", "Size": 1}],
+            "NextContinuationToken": "tok1",
+        },
+        {
+            "Contents": [{"Key": "p/b.txt", "Size": 2}],
+        },
+    ]
+    items = _list_s3_objects(client, "bucket", "p")
+    assert len(items) == 2
+    assert items[0]["Key"] == "p/a.txt"
+    assert items[1]["Key"] == "p/b.txt"
+    assert client.list_objects_v2.call_count == 2

--- a/tests/utils/test_aws.py
+++ b/tests/utils/test_aws.py
@@ -1,11 +1,8 @@
 """Tests for S3 download utilities in helia_edge.utils.aws."""
 
-import os
 import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from helia_edge.utils.aws import (
     download_s3_objects,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <3.15"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "helia-edge"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

`download_s3_objects` has a path-nesting bug: it joins `dst / item["Key"]` where the key includes the prefix, causing files to be nested one level too deep when `dst` already includes the prefix directory.

For example:
```python
# S3 key: "ptbxl/00001.h5"
# Calling: download_s3_objects(prefix="ptbxl", dst=Path("./data/ptbxl"))
# BUG: creates ./data/ptbxl/ptbxl/00001.h5  (prefix duplicated)
# EXPECTED:   ./data/ptbxl/00001.h5
```

### Impact across kits

| Kit | Caller | Works? | Why |
|---|---|---|---|
| heartkit | `IcentiaDataset.download()` | Yes | `dst=self.path.parent` — works by accident |
| sleepkit | `YsywDataset.download()` | Yes | Same accidental workaround |
| nnaed | `DcaseHandler.download()` | Yes | Same accidental workaround |
| nnaed | `CochlHandler.download()` | Broken | Double nesting; subsequent code expects flat |
| nnaed | `RirHandler.download()` | "Works" | Code anticipates bug with matching glob |

## Changes

- **`download_s3_prefix()`** — new function that **strips the prefix** from each S3 key before joining with `dst`, so `dst` is always the root of the downloaded tree. Returns count of files actually downloaded.
- **`download_s3_objects()`** — deprecated with `DeprecationWarning` pointing to the replacement. Behaviour intentionally preserved for callers that work around the bug.
- **`download_s3_object()`** — added `os.makedirs(dst.parent, exist_ok=True)` so nested sub-directories are created even without explicit S3 directory markers.
- **`_list_s3_objects()`** — extracted pagination helper for cleaner code.
- **`utils/__init__.py`** — exports `download_s3_prefix`.
- **9 pytest tests** covering prefix stripping, nested structures, directory markers, pagination, deprecation warning, and backward compatibility.

## Migration

Callers should replace:
```python
# Old (buggy — requires dst to be the PARENT of the prefix dir):
helia.utils.download_s3_objects(bucket="b", prefix="ptbxl", dst=path.parent)

# New (correct — dst IS the target directory):
helia.utils.download_s3_prefix(bucket="b", prefix="ptbxl", dst=path)
```