### PR TITLE
fix: chain PyPI publish in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,8 +13,51 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  build:
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    needs: release-please
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Build 🔧
+        run: uv build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    needs:
+      - release-please
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/helia-edge
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish to PyPI 📦
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,9 +13,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -23,41 +20,8 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  build:
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    needs: release-please
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-      - name: Build 🔧
-        run: uv build
-      - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-
-  publish:
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    needs:
-      - release-please
-      - build
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/helia-edge
-    permissions:
-      id-token: write
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Publish to PyPI 📦
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Trigger PyPI release
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run release.yaml --repo ${{ github.repository }} --ref ${{ steps.release.outputs.tag_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release to PyPi (manual)
+name: Release to PyPi
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,16 +1,6 @@
-name: Release to PyPi
-
-# on:
-#   release:
-#     types:
-#       - created
+name: Release to PyPi (manual)
 
 on:
-  release:
-    types: [published]
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Problem

The `release.yaml` (PyPI publish) workflow never triggers after release-please creates a release.

**Root cause:** GitHub Actions events triggered by `GITHUB_TOKEN` [do not trigger other workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). Since `release-please.yaml` uses the default `GITHUB_TOKEN` to create the GitHub Release and tag, the `release: [published]` and `push: tags: v*` events in `release.yaml` are silently suppressed.

## Fix

Chain the build + publish jobs directly in `release-please.yaml`, gated on the `release_created` output from the release-please action:

1. **`release-please.yaml`** — Added `build` and `publish` jobs that only run when `release_created == 'true'`. Uses the same build/publish steps that were in `release.yaml`.
2. **`release.yaml`** — Simplified to `workflow_dispatch` only, serving as a manual fallback.

## Flow (after this fix)

```
push to main
  → release-please job creates/updates release PR
  → when release PR merges, release-please creates GitHub Release
  → release_created == true
  → build job: uv build → upload artifact
  → publish job: download artifact → pypa/gh-action-pypi-publish
```